### PR TITLE
Add Register function and remove Init

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ func main() {
     config := zap.NewProductionEncoderConfig()
     logger := zap.New(zapcore.NewCore(
         zaplogfmt.NewEncoder(config),
-        os.Stdout,
+        zapcore.Lock(os.Stdout),
         zapcore.DebugLevel,
     ))
+    defer logger.Sync()
+
     logger.Info("Hello World")
 }
 ```
@@ -46,25 +48,28 @@ func main() {
     config.EncodeTime = zapcore.RFC3339TimeEncoder
     logger := zap.New(zapcore.NewCore(
         zaplogfmt.NewEncoder(config),
-        os.Stdout,
+        zapcore.Lock(os.Stdout),
         zapcore.DebugLevel,
     ))
+    defer logger.Sync()
+
     logger.Info("Hello World")
 }
 ```
 
-An alternative way to set up the logger using the config builder. Also setting the time encoding to RFC3339.
+An alternative way to set up the logger by registering the encoder and using it with the config builder. Also setting the time encoding to RFC3339.
 
 ```go
 package main
 
 import (
-    _ "github.com/allir/zap-logfmt"
+    zaplogfmt "github.com/allir/zap-logfmt"
     "go.uber.org/zap"
     "go.uber.org/zap/zapcore"
 )
 
 func main() {
+    zaplogfmt.Register()
     zapConfig := zap.NewProductionConfig()
     zapConfig.EncoderConfig = zap.NewProductionEncoderConfig()
     zapConfig.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
@@ -74,6 +79,7 @@ func main() {
     if err != nil {
         panic(err)
     }
+    defer logger.Sync()
 
     logger.Info("Hello World")
 }

--- a/example_test.go
+++ b/example_test.go
@@ -14,13 +14,37 @@ func Example_usage() {
 	logger := zap.New(
 		zapcore.NewCore(
 			zaplogfmt.NewEncoder(config),
-			os.Stdout,
+			zapcore.Lock(os.Stdout),
 			zapcore.DebugLevel),
 		zap.AddCaller(),
 		zap.AddStacktrace(zapcore.ErrorLevel),
 	).Named("main")
+	defer logger.Sync()
 
 	logger.Info("Hello World")
 
-	// Output: level=info logger=main caller=zap-logfmt/example_test.go:23 msg="Hello World"
+	// Output: level=info logger=main caller=zap-logfmt/example_test.go:24 msg="Hello World"
+}
+
+func Example_usage_register() {
+	zaplogfmt.Register()
+	zapConfig := zap.NewProductionConfig()
+	zapConfig.Encoding = "logfmt"
+	zapConfig.OutputPaths = []string{"stdout"} // Need to log to stdout for the test
+
+	zapConfig.EncoderConfig = zap.NewProductionEncoderConfig()
+	zapConfig.EncoderConfig.TimeKey = ""
+	zapConfig.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
+
+	logger, err := zapConfig.Build()
+	if err != nil {
+		panic(err)
+	}
+	defer logger.Sync()
+
+	logger = logger.Named("reg")
+
+	logger.Info("Hello World")
+
+	// Output: level=info logger=reg caller=zap-logfmt/example_test.go:47 msg="Hello World"
 }


### PR DESCRIPTION
Adding an exported Register function instead of init() for registering the Encoder with zap.

Updated Documentation and added test for the Register function.